### PR TITLE
Customizing categorical variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pCRscore"
-version = "0.0.7"
+version = "0.0.7+issue2"
 authors = [
   {name="Youness Azimzade"}
 ]

--- a/src/pCRscore/svm.py
+++ b/src/pCRscore/svm.py
@@ -28,7 +28,16 @@ def preprocess(data, split_var='Cohort', bin_vars='auto', cat_vars='auto'):
 
     # Creating dummy variables for the categorical variables
     if cat_vars == 'auto':
-        pass
+        # replace cat_vars with a list of variables that have between 5 and 4 unique values
+        cat_vars = data.select_dtypes('object').columns
+        for col in cat_vars:
+            if len(data[col].unique()) > 5 or len(data[col].unique()) < 3:
+                cat_vars = cat_vars.drop(col)
+        # Remove the 'Response' column from cat_vars
+        cat_vars = [col for col in cat_vars if col != 'Response']
+        # If no categorical variables are found, set cat_vars to None
+        if len(cat_vars) > 0:
+            data = pandas.get_dummies(data, columns=cat_vars)
     else:
         data = pandas.get_dummies(data, columns=cat_vars)
 

--- a/src/pCRscore/svm.py
+++ b/src/pCRscore/svm.py
@@ -14,8 +14,11 @@ def preprocess(data, split_var='Cohort'):
     resp = {'pCR': 1, 'RD': 0}
     data.Response = [resp[item] for item in data.Response]
 
-    # Mapping the values in the 'ER' column to binary values
-    data = _binary_encode(data, 'ER', out_values=[-1, 1])
+    # Sweep all columns. If coded as {Neg*, Pos*}, recode to {-1, 1}
+    for col in data.columns:
+        if len(data[col].unique()) == 2 and \
+        set(data[col].str[:3].unique()) in [{'Neg', 'Pos'}]:
+            data = _binary_encode(data, col, out_values=[-1, 1])
 
     # Creating dummy variables for the categorical column 'PAM50'
     categorical_cols = ['PAM50']

--- a/src/pCRscore/svm.py
+++ b/src/pCRscore/svm.py
@@ -9,7 +9,7 @@ from sklearn.svm import SVC
 from .misc import _binary_encode
 
 
-def preprocess(data, split_var='Cohort', bin_vars='auto'):
+def preprocess(data, split_var='Cohort', bin_vars='auto', cat_vars='auto'):
     # Mapping the values in the 'Response' column to binary values 0 and 1
     resp = {'pCR': 1, 'RD': 0}
     data.Response = [resp[item] for item in data.Response]
@@ -26,9 +26,11 @@ def preprocess(data, split_var='Cohort', bin_vars='auto'):
         for col in bin_vars:
             data = _binary_encode(data, col, out_values=[-1, 1])
 
-    # Creating dummy variables for the categorical column 'PAM50'
-    categorical_cols = ['PAM50']
-    data = pandas.get_dummies(data, columns=categorical_cols)
+    # Creating dummy variables for the categorical variables
+    if cat_vars == 'auto':
+        pass
+    else:
+        data = pandas.get_dummies(data, columns=cat_vars)
 
     # If split_var is None, randomly split the data
     if split_var is None:

--- a/src/pCRscore/svm.py
+++ b/src/pCRscore/svm.py
@@ -9,15 +9,21 @@ from sklearn.svm import SVC
 from .misc import _binary_encode
 
 
-def preprocess(data, split_var='Cohort'):
+def preprocess(data, split_var='Cohort', bin_vars='auto'):
     # Mapping the values in the 'Response' column to binary values 0 and 1
     resp = {'pCR': 1, 'RD': 0}
     data.Response = [resp[item] for item in data.Response]
 
-    # Sweep all columns. If coded as {Neg*, Pos*}, recode to {-1, 1}
-    for col in data.columns:
-        if len(data[col].unique()) == 2 and \
-        set(data[col].str[:3].unique()) in [{'Neg', 'Pos'}]:
+    # Recode variables listed under bin_vars to {-1, 1}
+    if bin_vars == 'auto':
+        # Sweep all columns. If coded as {Neg*, Pos*}, recode to {-1, 1}
+        for col in data.columns:
+            if len(data[col].unique()) == 2 and \
+                pandas.api.types.is_string_dtype(data[col]) and \
+                    set(data[col].str[:3].unique()) in [{'Neg', 'Pos'}]:
+                data = _binary_encode(data, col, out_values=[-1, 1])
+    else:
+        for col in bin_vars:
             data = _binary_encode(data, col, out_values=[-1, 1])
 
     # Creating dummy variables for the categorical column 'PAM50'

--- a/src/pCRscore/svm.py
+++ b/src/pCRscore/svm.py
@@ -28,7 +28,7 @@ def preprocess(data, split_var='Cohort', bin_vars='auto', cat_vars='auto'):
 
     # Creating dummy variables for the categorical variables
     if cat_vars == 'auto':
-        # replace cat_vars with a list of variables that have between 5 and 4 unique values
+        # replace cat_vars with vars that have between 5 and 4 unique values
         cat_vars = data.select_dtypes('object').columns
         for col in cat_vars:
             if len(data[col].unique()) > 5 or len(data[col].unique()) < 3:

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -56,7 +56,7 @@ def test_preprocess(mock_read_csv, mock_data):
     for col in ['Cohort']:
         data_disc = pd.read_csv("Data NAC cohort _1_.csv")  # returns mock
         data_valid = data_disc.copy()
-        data_disc, data_valid = svm.preprocess(data_disc, col)
+        data_disc, data_valid = svm.preprocess(data_disc, col, cat_vars=['PAM50'])
         data_valid['Trial'] = 'GSE25066'
 
         assert data_disc.shape[0] + data_valid.shape[0] == 100

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -33,17 +33,12 @@ def mock_data():
     )
 
     # Adding the non-numerical columns manually
-    df['Trial'] = 'E-MTAB-4439'
+    df['Trial'] = 'E-MTAB-4239'
     df['Mixture'] = 'Mixture1'
     df['Cohort'] = np.random.choice(['Discovery', 'Validation'], num_rows)
     df['Response'] = np.random.choice(['pCR', 'RD'], num_rows)
     df['ER'] = np.random.choice(['Positive', 'Negative'], num_rows)
-    df['PAM50'] = np.random.choice(['LumA', 'Basal'], num_rows)
-    df['PAM50_Normal'] = np.random.choice([True, False], num_rows)
-    df['PAM50_LumA'] = np.random.choice([True, False], num_rows)
-    df['PAM50_Her2'] = np.random.choice([True, False], num_rows)
-    df['PAM50_LumB'] = np.random.choice([True, False], num_rows)
-    df['PAM50_Basal'] = np.random.choice([True, False], num_rows)
+    df['PAM50'] = np.random.choice(['Normal', 'LumA', 'Her2', 'LumB', 'Basal'], num_rows)
 
     return df
 
@@ -61,14 +56,14 @@ def test_preprocess(mock_read_csv, mock_data):
 
         assert data_disc.shape[0] + data_valid.shape[0] == 100
         for dt in [data_disc, data_valid]:
-            assert dt.shape[1] == 48
+            assert dt.shape[1] == 46
             X, y = svm.extract_features(dt)
-            assert X.shape == (dt.shape[0], 44)
+            assert X.shape == (dt.shape[0], 42)
 
 
 @pytest.mark.slow
 def test_grid_search():
-    X = pd.DataFrame(np.random.randn(100, 44))
+    X = pd.DataFrame(np.random.randn(100, 42))
     y = np.random.choice([0, 1], 100)
     grid = svm.grid_search(X, y, n_cores=-2)
     assert isinstance(grid, svm.GridSearchCV)
@@ -77,7 +72,7 @@ def test_grid_search():
 
 
 def test_evaluate_model():
-    X = np.random.randn(100, 44)
+    X = np.random.randn(100, 42)
     y = np.random.choice([0, 1], 100)
     stats = svm.evaluate_model(X, y)
     assert isinstance(stats, dict)
@@ -87,19 +82,19 @@ def test_evaluate_model():
 
 
 def test_shapley():
-    X = pd.DataFrame(np.random.randn(30, 44))
+    X = pd.DataFrame(np.random.randn(30, 42))
     y = np.random.choice([0, 1], 30)
     shapl = svm.shap_analysis(X, y)
     assert isinstance(shapl, np.ndarray)
-    assert shapl.shape == (30, 44)
+    assert shapl.shape == (30, 42)
     svm.shap_plot(shapl, X)
 
 
 def test__binary_encode():
     # Test with likely data
-    data = pd.DataFrame({'PAM50': ['Lum', 'Bas', 'Lum', 'Bas', 'Lum', 'Bas']})
-    data_encoded = svm._binary_encode(data, 'PAM50')
-    data_ref = pd.DataFrame({'PAM50': [-1, 1, -1, 1, -1, 1]})
+    data = pd.DataFrame({'ER': ['Neg', 'Pos', 'Neg', 'Pos', 'Neg', 'Pos']})
+    data_encoded = svm._binary_encode(data, 'ER')
+    data_ref = pd.DataFrame({'ER': [-1, 1, -1, 1, -1, 1]})
     assert_frame_equal(data_encoded, data_ref)
 
     # Check that first value is always -1

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -51,7 +51,7 @@ def test_preprocess(mock_read_csv, mock_data):
     for col in ['Cohort']:
         data_disc = pd.read_csv("Data NAC cohort _1_.csv")  # returns mock
         data_valid = data_disc.copy()
-        data_disc, data_valid = svm.preprocess(data_disc, col, cat_vars=['PAM50'])
+        data_disc, data_valid = svm.preprocess(data_disc, col)
         data_valid['Trial'] = 'GSE25066'
 
         assert data_disc.shape[0] + data_valid.shape[0] == 100

--- a/tests/test_svm.py
+++ b/tests/test_svm.py
@@ -38,7 +38,9 @@ def mock_data():
     df['Cohort'] = np.random.choice(['Discovery', 'Validation'], num_rows)
     df['Response'] = np.random.choice(['pCR', 'RD'], num_rows)
     df['ER'] = np.random.choice(['Positive', 'Negative'], num_rows)
-    df['PAM50'] = np.random.choice(['Normal', 'LumA', 'Her2', 'LumB', 'Basal'], num_rows)
+    df['PAM50'] = np.random.choice(
+        ['Normal', 'LumA', 'Her2', 'LumB', 'Basal'], num_rows
+    )
 
     return df
 


### PR DESCRIPTION
# Summary

This PR does some more work on issue #2 by allowing the user to define which variables are binary and categorical.

Notice the discretionary rule for auto-defining a variable as multi-class (it muse have between 3 and 5 unique values). Hope this makes sense.

# Commits

- **Recode all Pos/Neg columns to -1/1 (#2)**
- **Added `bin_vars` argument (#2)**
- **Added `cat_vars` (#2)**
- **Updated version number**
- **Simplified test code**
- **Added auto-processing of categorical vars (#2)**

# Left to do in #2

Allowing the user to classify a multi-class variable as a binary one (see #2 for details).
